### PR TITLE
Docs: add org agent policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Organization policy for AI agents:
+
+- [karida-org/.github agent policy](https://github.com/karida-org/.github/blob/main/docs/agent-policy.md)
+
+Repositories may add a local `AGENTS.md` with repo-specific guidance.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This public repo holds Karida’s shared GitHub assets:
 
 - Organization profile content in `profile/`
 - Community health policies (Code of Conduct, contributing, support, security)
+- Organization-wide agent policy in `docs/agent-policy.md`
 - Shared pull request/issue templates
 - Reusable GitHub Actions workflow templates
 

--- a/docs/agent-policy.md
+++ b/docs/agent-policy.md
@@ -1,0 +1,32 @@
+# Agent Policy
+
+This document defines organization-wide guidance for AI agents working in Karida
+repositories. Repository-specific rules may extend this policy but should not
+conflict with it.
+
+## Issue-first workflow
+
+- Required for feature/bugfix work that affects user-facing behavior or touches multiple files.
+- Optional for docs, typos, and small single-file refactors.
+- Use the repo issue template if present.
+- Branch naming: `issue-<n>-<slug>` from `main`.
+- Manual merge after checks pass.
+
+Recommended command flow:
+
+```bash
+gh issue create --template issue-first.md --label "<label>"
+git checkout -b issue-<n>-<slug>
+pnpm lint && pnpm test
+gh pr create --title "<title>" --body "Fixes #<n>" --label "<label>"
+```
+
+## Labels
+
+- Apply labels on issues and PRs (use existing defaults like `bug`, `enhancement`, `documentation`).
+
+## Safety and hygiene
+
+- Never commit secrets or private keys.
+- Avoid destructive git commands unless explicitly requested.
+- Keep changes minimal and aligned with existing patterns.


### PR DESCRIPTION
## Summary
- add org-level agent policy documentation
- include an AGENTS.md pointer to the policy
- mention the policy in the org README

Fixes #1