### PR TITLE
Docs: add org workflows and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This public repo holds Karida’s shared GitHub assets:
 - Organization profile content in `profile/`
 - Community health policies (Code of Conduct, contributing, support, security)
 - Organization-wide agent policy in `docs/agent-policy.md`
+- Context maintenance workflow in `docs/context-maintenance.md`
+- Roadmap workflow in `docs/roadmap-workflow.md`
+- Tooling list in `docs/tooling.md`
 - Shared pull request/issue templates
 - Reusable GitHub Actions workflow templates
 

--- a/docs/agent-policy.md
+++ b/docs/agent-policy.md
@@ -4,6 +4,12 @@ This document defines organization-wide guidance for AI agents working in Karida
 repositories. Repository-specific rules may extend this policy but should not
 conflict with it.
 
+Related org docs:
+
+- `docs/context-maintenance.md`
+- `docs/roadmap-workflow.md`
+- `docs/tooling.md`
+
 ## Issue-first workflow
 
 - Required for feature/bugfix work that affects user-facing behavior or touches multiple files.

--- a/docs/context-maintenance.md
+++ b/docs/context-maintenance.md
@@ -1,0 +1,22 @@
+# Context Maintenance Workflow
+
+This workflow keeps org context accurate and lightweight across repositories.
+
+## When to update context
+
+- A user-facing behavior changes.
+- A new domain term is introduced.
+- A major decision or assumption is made.
+- A workflow or process changes.
+
+## What to update
+
+- Repo-specific `AGENTS.md` for local instructions only.
+- Org-level policy for rules that apply to all repos.
+- Decision logs where they exist (repo-specific).
+
+## Minimal checklist
+
+- Confirm the change is reflected in docs or specs.
+- Keep entries short and scannable.
+- Link to the most relevant file or issue when possible.

--- a/docs/roadmap-workflow.md
+++ b/docs/roadmap-workflow.md
@@ -1,0 +1,20 @@
+# Roadmap and Todo Workflow
+
+Use GitHub issues as the source of truth for roadmap items and tasks.
+
+## Issue usage
+
+- Create issues for feature/bugfix work above the threshold in the agent policy.
+- Keep issues small and scoped; split large items into multiple issues.
+- Close issues via PRs using "Fixes #<n>".
+
+## Milestones (by phase)
+
+- Group issues by phase (e.g., `MVP`, `Beta`, `Public`)
+- Keep milestones short and outcome-focused.
+- Move incomplete issues forward instead of extending milestone dates.
+
+## Labels
+
+- Use existing defaults: `enhancement`, `bug`, `documentation`.
+- Add phase labels only if milestones are not sufficient.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,12 @@
+# Tooling
+
+This list covers tools used across Karida repositories.
+
+## Required
+
+- GitHub CLI (`gh`)
+
+## Recommended
+
+- OpenCode
+- Codex review


### PR DESCRIPTION
## Summary
- add org workflows for context maintenance and roadmap management
- add tooling guidance
- link new docs from agent policy and README

Fixes #3