### PR TITLE
docs: clarify repo AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,5 @@ Organization policy for AI agents:
 
 - [karida-org/.github agent policy](https://github.com/karida-org/.github/blob/main/docs/agent-policy.md)
 
-Repositories may add a local `AGENTS.md` with repo-specific guidance.
+Repositories may add a local `AGENTS.md` with repo-specific guidance (commands, conventions, architecture).
+Do not copy org-wide policy into repo files; link to the policy doc instead.

--- a/docs/agent-policy.md
+++ b/docs/agent-policy.md
@@ -10,6 +10,12 @@ Related org docs:
 - `docs/roadmap-workflow.md`
 - `docs/tooling.md`
 
+## Repository AGENTS.md files
+
+- Keep repo `AGENTS.md` focused on repo-specific guidance (commands, architecture, conventions, tests).
+- Do not copy org-wide policy into repo files; link to this document instead to avoid drift.
+- Repo rules may extend this policy but should be minimal and must not conflict.
+
 ## Issue-first workflow
 
 - Required for feature/bugfix work that affects user-facing behavior or touches multiple files.


### PR DESCRIPTION
## Summary
- clarify that repo AGENTS.md files should be repo-specific and link to org policy
- add explicit guidance in the org-wide agent policy doc to prevent duplication drift

## Testing
- not run (docs-only)

Fixes #7