### PR TITLE
feat: reusable Action Pinning Check + canonical pinact/dependabot config

### DIFF
--- a/.github/workflows/reusable-pinact-check.yml
+++ b/.github/workflows/reusable-pinact-check.yml
@@ -23,6 +23,9 @@ name: "[REUSABLE] Action Pinning Check"
 #   jobs:
 #     pinact:
 #       uses: karida-org/.github/.github/workflows/reusable-pinact-check.yml@v1
+#       # SHA-pin this ref in your repo: run pinact (or let the Action Pinning
+#       # Check guide you) to turn @v1 into "@<sha>  # v1"; Dependabot then keeps
+#       # it current. The floating @v1 above is only the copy-paste starting point.
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-pinact-check.yml
+++ b/.github/workflows/reusable-pinact-check.yml
@@ -1,0 +1,60 @@
+name: "[REUSABLE] Action Pinning Check"
+
+# Per-PR gate that verifies every GitHub Action and reusable workflow
+# referenced in the caller repo is:
+#
+#   1. pinned to a full 40-char commit SHA,
+#   2. annotated with a version comment that matches that SHA, and
+#   3. at least the minimum release age set in the repo's .pinact.yml
+#      (org default: 7 days).
+#
+# It runs pinact in validation-only mode (fix: false): it never edits a
+# file or pushes a commit, it only fails the check when something is off.
+# Pair it with a repo-root .pinact.yml and Dependabot (github-actions,
+# weekly, with a matching cooldown) so pins stay current without manual
+# SHA edits.
+#
+# Consumer wrapper (in any repo):
+#
+#   name: Action Pinning Check
+#   on:
+#     pull_request:
+#       branches: [main]
+#   jobs:
+#     pinact:
+#       uses: karida-org/.github/.github/workflows/reusable-pinact-check.yml@v1
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner label for the check job."
+        type: string
+        required: false
+        default: "ubuntu-latest"
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    name: pinact (verify pins)
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify action pins
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          # Validation only: pinact reports problems and exits non-zero,
+          # but never rewrites workflows or pushes a fix from CI.
+          fix: "false"
+          # --verify-comment: the version comment must match the pinned SHA.
+          verify: "true"
+          # --verify-min-age: enforce the .pinact.yml minimum release age
+          # against the currently pinned versions.
+          verify_min_age: "true"

--- a/pinact/.pinact.yml
+++ b/pinact/.pinact.yml
@@ -1,0 +1,44 @@
+# Canonical pinact config for the karida-org org.
+#
+# Drop this file at the root of your repository as `.pinact.yml`. pinact
+# reads it both locally (pre-commit, manual `pinact run`) and in CI (the
+# Action Pinning Check), so local and CI behave identically. Requires
+# pinact v4+ (the `version` field below).
+#
+# What it does:
+#
+#   min_age.value: 7    Do not pin (or update to) an action release that
+#                       is younger than 7 days. A freshly published tag or
+#                       release is the window when a hijacked-tag supply
+#                       chain attack is most likely to still be live, so
+#                       we wait it out. This is the GitHub Actions analog
+#                       of pnpm's `minimumReleaseAge`.
+#
+#   min_age.always: true  Verify the 7-day age of CURRENT pins on every
+#                       run, not only when `--verify-min-age` is passed.
+#                       Keeps the rule on by default for local runs.
+#
+#   rules (karida-org/*)  Exempt our own org from the cooldown. The 7-day
+#                       window guards against a hijacked THIRD-PARTY
+#                       release; we author and control karida-org/* releases
+#                       ourselves, and a brand-new karida-org/.github
+#                       reusable would otherwise be un-adoptable for a
+#                       week (no older release contains it). Still
+#                       SHA-pinned; Dependabot maintains them.
+#
+# Pin comments use pinact's default single-space separator (`@<sha> # vX.Y.Z`),
+# which is also what Prettier emits for YAML, so the two never fight.
+#
+# Bump an action by letting Dependabot (github-actions, weekly, with an
+# 8-day cooldown: one day over this min_age, so its PRs always clear the
+# pinact gate) open the PR, or run `pinact run --update` locally. Do not
+# hand-edit the SHA or the version comment; pinact keeps the two in sync.
+version: 3
+min_age:
+  value: 7
+  always: true
+rules:
+  - min_age: 0
+    conditions:
+      - expr: |
+          ActionName matches "karida-org/.*"

--- a/pinact/.pre-commit-config.example.yaml
+++ b/pinact/.pre-commit-config.example.yaml
@@ -1,0 +1,37 @@
+# Example pre-commit-framework config for the karida-org org.
+#
+# Drop this file at the root of your repository as `.pre-commit-config.yaml`
+# (merge the `repos:` list if you already have one), then run once per
+# laptop:
+#
+#   brew install pre-commit pinact   # pinact tap: suzuki-shunsuke/pinact
+#   pre-commit install
+#
+# After that, `git commit` runs pinact on the staged workflow files and
+# pins any unpinned action (and refuses the commit if a pin is younger
+# than the 7-day minimum release age in .pinact.yml). Same engine and
+# same rules as the per-PR Action Pinning Check, so feedback is
+# consistent between local and CI.
+#
+# pinact must be on PATH. Install it with Homebrew (above), aqua, or
+# `go install github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.0.0`.
+# Pin the same v4 line that the CI gate (pinact-action v3) bundles, so
+# local and CI use the same engine.
+#
+# Bypass for the rare commit that must go in despite the hook
+# (the CI gate still catches it on the PR):
+#
+#   git commit --no-verify
+
+repos:
+  - repo: local
+    hooks:
+      - id: pinact
+        name: pinact (pin GitHub Actions)
+        entry: pinact run
+        language: system
+        # Only run when a workflow or action definition changes. Matches
+        # workflow files plus action.yml/action.yaml at any depth (composite
+        # actions live in subdirectories).
+        files: (^\.github/workflows/.*\.ya?ml$|(^|/)action\.ya?ml$)
+        pass_filenames: false

--- a/workflow-templates/pinact-check.properties.json
+++ b/workflow-templates/pinact-check.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Action Pinning Check (per PR)",
+  "description": "Verify every GitHub Action is pinned to a commit SHA with a matching version comment and meets the org 7-day minimum release age, using pinact. Requires a .pinact.yml at the repo root.",
+  "iconName": "lock",
+  "categories": ["Automation"],
+  "filePatterns": [".github/workflows/.*"]
+}

--- a/workflow-templates/pinact-check.yml
+++ b/workflow-templates/pinact-check.yml
@@ -1,0 +1,17 @@
+name: Action Pinning Check
+
+on:
+  pull_request:
+    branches: [$default-branch]
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    uses: karida-org/.github/.github/workflows/reusable-pinact-check.yml@v1
+    # Verifies every GitHub Action in this repo is SHA-pinned, carries a
+    # matching version comment, and meets the 7-day minimum release age.
+    # Requires a .pinact.yml at the repo root (copy the org canonical one
+    # from karida-org/.github: pinact/.pinact.yml) and pairs with a
+    # Dependabot github-actions config to keep pins current.

--- a/workflow-templates/pinact-check.yml
+++ b/workflow-templates/pinact-check.yml
@@ -9,6 +9,9 @@ permissions:
 
 jobs:
   pinact:
+    # Workflow-template scaffold: the @v1 below is a starting point. After you
+    # add this file, run pinact (or the Action Pinning Check will flag it) so it
+    # becomes "@<sha>  # v1"; Dependabot then keeps the pin current.
     uses: karida-org/.github/.github/workflows/reusable-pinact-check.yml@v1
     # Verifies every GitHub Action in this repo is SHA-pinned, carries a
     # matching version comment, and meets the 7-day minimum release age.


### PR DESCRIPTION
Foundation for rolling out SHA-pinned GitHub Actions + Dependabot across the org. Consumer repos reference the reusable; this PR just provides it.

## Adds

- **`.github/workflows/reusable-pinact-check.yml`** — reusable per-PR gate (`suzuki-shunsuke/pinact-action` v3.0.0, SHA-pinned), validation only (`fix: false`, `--verify-comment`, `--verify-min-age`). Consume with:
  ```yaml
  jobs:
    pinact:
      uses: karida-org/.github/.github/workflows/reusable-pinact-check.yml@v1
  ```
- **`workflow-templates/pinact-check.yml`** (+ `.properties.json`) — Actions-picker template (thin caller).
- **`pinact/.pinact.yml`** — canonical config: `version: 3`, `min_age 7/always`, `karida-org/*` cooldown exemption.
- **`pinact/.pre-commit-config.example.yaml`** — local auto-pin hook.

## The standard

- SHA-pin every `uses:` ref with a `# vX.Y.Z` comment (incl. `karida-org/*` self-refs; Dependabot maintains them).
- Dependabot `github-actions` weekly, **cooldown: 8** (one day over pinact's **min_age: 7**, to clear the sub-day boundary race).
- `karida-org/*` exempt from the cooldown (we author our own releases).

## After merge

Cut a **`v1.2.0`** release (the repo is already at v1.1.0; this adds a new reusable workflow, so a minor bump) so the release automation moves the floating **`@v1`** onto a commit that includes the reusable, which the consumer callers reference. Then the per-repo rollout (callers + `.pinact.yml` + `dependabot.yml` + SHA-pinning existing workflows) lands in `srv_redmine`, `srv_registry`, `redmine_custom`, `cloud`, `meshtastic-hub`.

karida-org/.github's own release workflows will be SHA-pinned + gated in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable GitHub Actions workflow and a workflow template to validate action pinning on pull requests
  * Pull-request check now enforces version-comment matching and a configurable minimum release age

* **Chores**
  * Added repository configuration to define minimum-age policy and exemption rules
  * Added an example pre-commit configuration to enable local validation of workflow pins
<!-- end of auto-generated comment: release notes by coderabbit.ai -->